### PR TITLE
Synchronously refresh token before starting background loop

### DIFF
--- a/client/file_reading_client.go
+++ b/client/file_reading_client.go
@@ -23,6 +23,8 @@ func (frc *fileReadingClient) started(ctx context.Context) Interface {
 		frc.loopInterval = 1 * time.Hour
 	}
 
+	_ = frc.refreshToken()
+
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
so that the cached values are warmed prior to usage.